### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/elizhyu/elizhyu.github.io/security/code-scanning/24](https://github.com/elizhyu/elizhyu.github.io/security/code-scanning/24)

To fix the issue, you should add a `permissions` block with least-privilege settings at the workflow root (so it applies to all jobs, unless locally overridden). In this case, that's directly under the workflow’s `name` line. Since Super-Linter only requires read-access to the repository code to perform its checks, setting `contents: read` is appropriate. Edit `.github/workflows/super-linter.yml` and insert:

```yaml
permissions:
  contents: read
```

immediately after the `name` key and before the `on:` key.

No changes to jobs, steps, or other sections are needed, and no additional libraries or configuration are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
